### PR TITLE
Improve spinner timings in CheckoutWithCard component

### DIFF
--- a/.changeset/twenty-mails-buy.md
+++ b/.changeset/twenty-mails-buy.md
@@ -1,0 +1,5 @@
+---
+"@paperxyz/react-client-sdk": minor
+---
+
+fix: hide loading spinner if no callback from inner iframe takes too long

--- a/packages/react-client-sdk/src/components/CheckoutWithCard.tsx
+++ b/packages/react-client-sdk/src/components/CheckoutWithCard.tsx
@@ -65,6 +65,15 @@ export const CheckoutWithCard = ({
   const CheckoutWithCardIframeContainerRef = useRef<HTMLDivElement>(null);
   const appNameToUse = appName || appNameContext;
 
+  // force hide spinner if iframe taking too long
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setIsCardDetailIframeLoading(false);
+    }, 1000);
+    return () => {
+      clearTimeout(timer); // Clear the timer if the component unmounts before the delay
+    };
+  }, []);
   // Handle message events from the popup. Pass along the message to the iframe as well
   useEffect(() => {
     if (!CheckoutWithCardIframeContainerRef.current) {


### PR DESCRIPTION
hide loading spinner if no callback from inner iframe takes too long (onLoad only runs after Stripe content is fully loaded, user can and should start entering info before then)