### PR TITLE
Update chains & RPC endpoints

### DIFF
--- a/packages/sdk-common-utilities/src/constants/blockchain.ts
+++ b/packages/sdk-common-utilities/src/constants/blockchain.ts
@@ -1,9 +1,9 @@
 export const ChainToPublicRpc: Record<Chain, string> = {
-  Ethereum: "https://rpc.ankr.com/eth",
-  Goerli: "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161",
-  Mumbai: "https://rpc-mumbai.maticvigil.com",
-  Polygon: "https://rpc-mainnet.maticvigil.com",
-  Avalanche: "https://api.avax.network/ext/bc/C/rpc",
+  Ethereum: "https://ethereum.rpc.thirdweb.com",
+  Goerli: "https://goerli.rpc.thirdweb.com",
+  Mumbai: "https://mumbai.rpc.thirdweb.com",
+  Polygon: "https://polygon.rpc.thirdweb.com",
+  Avalanche: "https://avalanche.rpc.thirdweb.com",
   Optimism: "https://optimism.rpc.thirdweb.com",
   OptimismGoerli: "https://optimism-goerli.rpc.thirdweb.com",
   BSC: "https://binance.rpc.thirdweb.com",
@@ -13,7 +13,7 @@ export const ChainToPublicRpc: Record<Chain, string> = {
   Fantom: "https://fantom.rpc.thirdweb.com",
   FantomTestnet: "https://fantom-testnet.rpc.thirdweb.com",
   Sepolia: "https://sepolia.rpc.thirdweb.com",
-  AvalancheFuji: "https://api.avax-test.network/ext/bc/C/rpc",
+  AvalancheFuji: "https://avalanche-fuji.rpc.thirdweb.com",
 };
 
 // General Embedded wallet types

--- a/packages/sdk-common-utilities/src/constants/blockchain.ts
+++ b/packages/sdk-common-utilities/src/constants/blockchain.ts
@@ -12,6 +12,8 @@ export const ChainToPublicRpc: Record<Chain, string> = {
   ArbitrumGoerli: "https://arbitrum-goerli.rpc.thirdweb.com",
   Fantom: "https://fantom.rpc.thirdweb.com",
   FantomTestnet: "https://fantom-testnet.rpc.thirdweb.com",
+  Sepolia: "https://sepolia.rpc.thirdweb.com",
+  AvalancheFuji: "https://api.avax-test.network/ext/bc/C/rpc",
 };
 
 // General Embedded wallet types
@@ -28,6 +30,8 @@ export type Chain =
   | "ArbitrumOne"
   | "ArbitrumGoerli"
   | "Fantom"
-  | "FantomTestnet";
+  | "FantomTestnet"
+  | "Sepolia"
+  | "AvalancheFuji";
 
 export type SupportedChainName = Chain | "Rinkeby" | "Solana" | "SolanaDevnet";


### PR DESCRIPTION
Add support for Sepolia and Avalanche Fuji.
Set RPC urls for all chain to use thirdweb.