### PR TITLE
fix: linting errors in react-client-sdk-checkout-with-eth

### DIFF
--- a/packages/react-client-sdk-checkout-with-eth/package.json
+++ b/packages/react-client-sdk-checkout-with-eth/package.json
@@ -4,7 +4,6 @@
   "version": "0.0.6",
   "license": "Apache-2.0",
   "main": "dist/index.js",
-  "type": "module",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
## Changes

- This PR fixes the linting errors in react-client-sdk-checkout-with-eth that came from a premature push to main yesterday
 
## Checklist

- [] tests passing
 
## How to reproduce for testing

- Checkout branch
- yarn lint