### PR TITLE
chore: bump react-client-sdk-checkout-with-eth js-client-sdk dependency

### DIFF
--- a/.changeset/metal-humans-love.md
+++ b/.changeset/metal-humans-love.md
@@ -1,0 +1,5 @@
+---
+"@paperxyz/react-client-sdk-checkout-with-eth": patch
+---
+
+Bumped js-client-sdk version dependency in react-client-sdk-checkout-with-eth

--- a/packages/react-client-sdk-checkout-with-eth/package.json
+++ b/packages/react-client-sdk-checkout-with-eth/package.json
@@ -50,8 +50,8 @@
   "dependencies": {
     "@emotion/css": "11.10.5",
     "@headlessui/react": "1.7.6",
-    "@paperxyz/js-client-sdk": "0.0.0-gerry-backendless-20230622005836",
-    "@paperxyz/sdk-common-utilities": "^0.0.5",
+    "@paperxyz/js-client-sdk": "*",
+    "@paperxyz/sdk-common-utilities": "*",
     "ethers": "^5.7.2",
     "wagmi": "0.7.15"
   },


### PR DESCRIPTION
## Changes

- Bumped version of `js-client-sdk` in `react-client-sdk-checkout-with-eth`
