### PR TITLE
fix: CheckoutWithCard mintMethod.args should be an object

### DIFF
--- a/.changeset/swift-pots-hang.md
+++ b/.changeset/swift-pots-hang.md
@@ -1,0 +1,5 @@
+---
+"@paperxyz/js-client-sdk": patch
+---
+
+fix: ICheckoutWithCard mintMethod.args is now an object type (previously array)

--- a/packages/js-client-sdk/src/interfaces/CheckoutWithCard.ts
+++ b/packages/js-client-sdk/src/interfaces/CheckoutWithCard.ts
@@ -45,7 +45,7 @@ export interface ICheckoutWithCardConfigs {
   quantity?: number;
   mintMethod?: {
     name: string;
-    args: Record<string, any>[];
+    args: Record<string, any>;
     payment: { value: string; currency: string };
   };
   contractArgs?: Record<string, any>;


### PR DESCRIPTION
## Changes

- ICheckoutWithCard.mintMethod.args is now an object type (previous array type)
