### PR TITLE
fix: Stop and reload the page after switching chain (checkout-with-eth)

### DIFF
--- a/.changeset/stupid-rules-draw.md
+++ b/.changeset/stupid-rules-draw.md
@@ -1,0 +1,5 @@
+---
+"@paperxyz/react-client-sdk-checkout-with-eth": patch
+---
+
+fix: Stop execution after switching chains to avoid sendTransaction error.


### PR DESCRIPTION
## Changes

- Return after switching chains to not try to sendTransaction. The iframe should reload upon changing chains.

While this isn't the best UX, it at least allows the user to continue with the checkout flow after switching chains.


## Screenshots

![8572C599-7D3B-43C6-97B2-5FE500BFD341](https://github.com/paperxyz/js-sdk/assets/7673418/29aa86aa-a59a-46e8-bfa0-07f77ce7b6b3)

## How to reproduce for testing

- Publish version and bump version for paper-web. Test on checkout page.
- Start with a non-Ethereum/Goerli chain. This flow should prompt to switch to that chain, reload JUST the iframe (not the entire checkout), and allow continuing to payment.
