### PR TITLE
fix(ews): silence login with google error and update return message type

### DIFF
--- a/packages/embedded-wallet-service-sdk/src/lib/Auth/AwsManagedLogin.ts
+++ b/packages/embedded-wallet-service-sdk/src/lib/Auth/AwsManagedLogin.ts
@@ -39,9 +39,13 @@ export class AwsManagedLogin extends AbstractLogin<
         if (!win) {
           return;
         }
-        if (win.closed) {
-          clearInterval(pollTimer);
-          reject(new Error("User closed login window"));
+        try {
+          if (win.closed) {
+            clearInterval(pollTimer);
+            reject(new Error("User closed login window"));
+          }
+        } catch (e) {
+          // silence the error since it'll throw when the user closes it on the google auth page
         }
       }, 1000);
 
@@ -70,7 +74,7 @@ export class AwsManagedLogin extends AbstractLogin<
             }
             break;
           }
-          case "userLoginFailure": {
+          case "userLoginFailed": {
             win?.close();
             reject(new Error(event.data.error));
             break;


### PR DESCRIPTION
## Changes

- This PR Addresses some issues with the paper implementation of headless google auth
